### PR TITLE
Update centralised_query.rq to use the same predicate as federated query

### DIFF
--- a/centralised_query.rq
+++ b/centralised_query.rq
@@ -8,14 +8,13 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX orth: <http://purl.org/net/orth#>
 PREFIX genex: <http://purl.org/genex#>
 PREFIX umls: <http://linkedlifedata.com/resource/umls/id/>
-PREFIX bgee: <http://bgee.org/#>
 
 SELECT DISTINCT ?mouse ?homepage_mouse ?ensembl2
 WHERE {
   GRAPH <http://metadb.riken.jp/db/bgee> {
     ?oma_gene2 a orth:Gene .
     ?oma_gene2 lscr:xrefEnsemblGene ?ensembl2 .
-    ?oma_gene2 orth:organism bgee:ORGANISM_9606 . # human
+    ?oma_gene2 orth:organism/obo:RO_0002162 taxon:9606 . # human
     ?oma_gene2 genex:isExpressedIn ?cond .
     ?cond genex:hasAnatomicalEntity obo:UBERON_0000451 . # prefrontal cortex
     ?expr genex:hasExpressionCondition ?cond .


### PR DESCRIPTION
It did not change the result, nor the speed,
and simplifies the diff of federated vs centralized.
```
$ diff federated_query.rq centralised_query.rq
14c14
<   SERVICE <https://bgee.org/sparql/> {
---
>   GRAPH <http://metadb.riken.jp/db/bgee> {
```